### PR TITLE
adding curl retry when curl fails

### DIFF
--- a/dcos-versions/1.10.0-rc1/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.10.0-rc1/dcos-bootstrap/templates/install/run.sh
@@ -75,7 +75,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1

--- a/dcos-versions/1.10.0-rc1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.10.0-rc1/dcos-bootstrap/templates/upgrade/run.sh
@@ -80,7 +80,7 @@ cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "s
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.10.0/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.10.0/dcos-bootstrap/templates/install/run.sh
@@ -75,7 +75,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1

--- a/dcos-versions/1.10.0/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.10.0/dcos-bootstrap/templates/upgrade/run.sh
@@ -80,7 +80,7 @@ cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "s
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.10.1/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.10.1/dcos-bootstrap/templates/install/run.sh
@@ -75,7 +75,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1

--- a/dcos-versions/1.10.1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.10.1/dcos-bootstrap/templates/upgrade/run.sh
@@ -80,7 +80,7 @@ cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "s
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.10.2/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.10.2/dcos-bootstrap/templates/install/run.sh
@@ -74,7 +74,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1

--- a/dcos-versions/1.10.2/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.10.2/dcos-bootstrap/templates/upgrade/run.sh
@@ -79,7 +79,7 @@ cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "s
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.10.4/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.10.4/dcos-bootstrap/templates/install/run.sh
@@ -74,7 +74,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1

--- a/dcos-versions/1.10.4/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.10.4/dcos-bootstrap/templates/upgrade/run.sh
@@ -79,7 +79,7 @@ cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "s
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.10.5/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.10.5/dcos-bootstrap/templates/install/run.sh
@@ -75,7 +75,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1

--- a/dcos-versions/1.10.5/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.10.5/dcos-bootstrap/templates/upgrade/run.sh
@@ -80,7 +80,7 @@ cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "s
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.10.6/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.10.6/dcos-bootstrap/templates/install/run.sh
@@ -97,7 +97,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ${dcos_config== "" ? "" : "${dcos_config}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/fault-domain-detect file"; else echo "copied file /tmp/fault-domain-detect to ~/genconf"; fi

--- a/dcos-versions/1.10.6/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.10.6/dcos-bootstrap/templates/upgrade/run.sh
@@ -104,7 +104,7 @@ cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skippi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.11.0-rc1/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.11.0-rc1/dcos-bootstrap/templates/install/run.sh
@@ -97,7 +97,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ${dcos_config== "" ? "" : "${dcos_config}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/fault-domain-detect file"; else echo "copied file /tmp/fault-domain-detect to ~/genconf"; fi

--- a/dcos-versions/1.11.0-rc1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.11.0-rc1/dcos-bootstrap/templates/upgrade/run.sh
@@ -104,7 +104,7 @@ cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skippi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.11.0-rc4/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.11.0-rc4/dcos-bootstrap/templates/install/run.sh
@@ -97,7 +97,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ${dcos_config== "" ? "" : "${dcos_config}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/fault-domain-detect file"; else echo "copied file /tmp/fault-domain-detect to ~/genconf"; fi

--- a/dcos-versions/1.11.0-rc4/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.11.0-rc4/dcos-bootstrap/templates/upgrade/run.sh
@@ -104,7 +104,7 @@ cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skippi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.11.0/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.11.0/dcos-bootstrap/templates/install/run.sh
@@ -97,7 +97,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ${dcos_config== "" ? "" : "${dcos_config}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/fault-domain-detect file"; else echo "copied file /tmp/fault-domain-detect to ~/genconf"; fi

--- a/dcos-versions/1.11.0/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.11.0/dcos-bootstrap/templates/upgrade/run.sh
@@ -104,7 +104,7 @@ cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skippi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.11.1/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.11.1/dcos-bootstrap/templates/install/run.sh
@@ -97,7 +97,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ${dcos_config== "" ? "" : "${dcos_config}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/fault-domain-detect file"; else echo "copied file /tmp/fault-domain-detect to ~/genconf"; fi

--- a/dcos-versions/1.11.1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.11.1/dcos-bootstrap/templates/upgrade/run.sh
@@ -104,7 +104,7 @@ cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skippi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.11.2/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.11.2/dcos-bootstrap/templates/install/run.sh
@@ -97,7 +97,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ${dcos_config== "" ? "" : "${dcos_config}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/fault-domain-detect file"; else echo "copied file /tmp/fault-domain-detect to ~/genconf"; fi

--- a/dcos-versions/1.11.2/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.11.2/dcos-bootstrap/templates/upgrade/run.sh
@@ -104,7 +104,7 @@ cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skippi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.7-open/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.7-open/dcos-bootstrap/templates/install/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.7-open/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.7-open/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.7.1/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.7.1/dcos-bootstrap/templates/install/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.7.1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.7.1/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.7.2/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.7.2/dcos-bootstrap/templates/install/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.7.2/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.7.2/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.7.3/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.7.3/dcos-bootstrap/templates/install/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.7.3/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.7.3/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.7.4/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.7.4/dcos-bootstrap/templates/install/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.7.4/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.7.4/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.7/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.7/dcos-bootstrap/templates/install/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.7/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.7/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.8.1/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.8.1/dcos-bootstrap/templates/install/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.8.1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.8.1/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.8.2/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.8.2/dcos-bootstrap/templates/install/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.8.2/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.8.2/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.8.3/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.8.3/dcos-bootstrap/templates/install/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.8.3/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.8.3/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.8.4/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.8.4/dcos-bootstrap/templates/install/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.8.4/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.8.4/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.8.5/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.8.5/dcos-bootstrap/templates/install/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.8.5/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.8.5/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.8.6/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.8.6/dcos-bootstrap/templates/install/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.8.6/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.8.6/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.8.7/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.8.7/dcos-bootstrap/templates/install/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.8.7/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.8.7/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.8.8/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.8.8/dcos-bootstrap/templates/install/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.8.8/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.8.8/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.8.9/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.8.9/dcos-bootstrap/templates/install/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.8.9/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.8.9/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.8/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.8/dcos-bootstrap/templates/install/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.8/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.8/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,7 +72,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.9.0-rc1/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.9.0-rc1/dcos-bootstrap/templates/install/run.sh
@@ -73,7 +73,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.9.0-rc1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.9.0-rc1/dcos-bootstrap/templates/upgrade/run.sh
@@ -77,7 +77,7 @@ cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.9.0-rc2/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.9.0-rc2/dcos-bootstrap/templates/install/run.sh
@@ -73,7 +73,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.9.0-rc2/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.9.0-rc2/dcos-bootstrap/templates/upgrade/run.sh
@@ -77,7 +77,7 @@ cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.9.0-rc3/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.9.0-rc3/dcos-bootstrap/templates/install/run.sh
@@ -73,7 +73,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.9.0-rc3/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.9.0-rc3/dcos-bootstrap/templates/upgrade/run.sh
@@ -77,7 +77,7 @@ cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.9.0-rc4/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.9.0-rc4/dcos-bootstrap/templates/install/run.sh
@@ -73,7 +73,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.9.0-rc4/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.9.0-rc4/dcos-bootstrap/templates/upgrade/run.sh
@@ -77,7 +77,7 @@ cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.9.0/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.9.0/dcos-bootstrap/templates/install/run.sh
@@ -73,7 +73,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.9.0/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.9.0/dcos-bootstrap/templates/upgrade/run.sh
@@ -77,7 +77,7 @@ cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.9.1/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.9.1/dcos-bootstrap/templates/install/run.sh
@@ -73,7 +73,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.9.1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.9.1/dcos-bootstrap/templates/upgrade/run.sh
@@ -77,7 +77,7 @@ cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.9.2/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.9.2/dcos-bootstrap/templates/install/run.sh
@@ -73,7 +73,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.9.2/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.9.2/dcos-bootstrap/templates/upgrade/run.sh
@@ -77,7 +77,7 @@ cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.9.3/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.9.3/dcos-bootstrap/templates/install/run.sh
@@ -73,7 +73,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.9.3/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.9.3/dcos-bootstrap/templates/upgrade/run.sh
@@ -77,7 +77,7 @@ cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.9.4/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.9.4/dcos-bootstrap/templates/install/run.sh
@@ -73,7 +73,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.9.4/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.9.4/dcos-bootstrap/templates/upgrade/run.sh
@@ -77,7 +77,7 @@ cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.9.5/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.9.5/dcos-bootstrap/templates/install/run.sh
@@ -73,7 +73,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.9.5/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.9.5/dcos-bootstrap/templates/upgrade/run.sh
@@ -77,7 +77,7 @@ cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.9.6/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.9.6/dcos-bootstrap/templates/install/run.sh
@@ -73,7 +73,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.9.6/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.9.6/dcos-bootstrap/templates/upgrade/run.sh
@@ -77,7 +77,7 @@ cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.9.7/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.9.7/dcos-bootstrap/templates/install/run.sh
@@ -73,7 +73,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.9.7/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.9.7/dcos-bootstrap/templates/upgrade/run.sh
@@ -77,7 +77,7 @@ cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/1.9.8/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/1.9.8/dcos-bootstrap/templates/install/run.sh
@@ -73,7 +73,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : dcos_package_storage_uri == "" ? 
 ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${dcos_staged_package_storage_uri}"}
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 bash dcos_generate_config.${dcos_version}.sh || exit 1
 docker rm -f $(docker ps -a -q -f ancestor=nginx) &> /dev/null; if [[ $? -eq 0 ]]; then echo "reloaded nginx..."; fi

--- a/dcos-versions/1.9.8/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.9.8/dcos-bootstrap/templates/upgrade/run.sh
@@ -77,7 +77,7 @@ cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current

--- a/dcos-versions/master/dcos-bootstrap/templates/install/run.sh
+++ b/dcos-versions/master/dcos-bootstrap/templates/install/run.sh
@@ -97,7 +97,7 @@ ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 ${dcos_config== "" ? "" : "${dcos_config}"}
 EOF
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 cp /tmp/ip-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect file"; else echo "copied file /tmp/ip-detect to ~/genconf"; fi
 cp /tmp/ip-detect-public genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/ip-detect-public file"; else echo "copied file /tmp/ip-detect-public to ~/genconf"; fi
 cp /tmp/fault-domain-detect genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skipping absent /tmp/fault-domain-detect file"; else echo "copied file /tmp/fault-domain-detect to ~/genconf"; fi

--- a/dcos-versions/master/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/master/dcos-bootstrap/templates/upgrade/run.sh
@@ -104,7 +104,7 @@ cp /tmp/license.txt genconf/. &> /dev/null; if [[ $? -ne 0 ]]; then echo "skippi
 OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 # TODO(bernadinm) Terraform Bug: 9488. Templates will not accept list, but only strings. Used for PREVIOUS_DCOS_VERSION generation.
 PREVIOUS_DCOS_VERSION=$(curl -ksL ${element(compact(split("\n - ","${dcos_master_list}")),"${dcos_previous_version_master_index}")}/dcos-metadata/dcos-version.json | grep version | cut -d ":" -f2 | sed 's/ //g' | sed 's/,$//' | sed 's/\"//g')
-curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
+for i in {1..5}; do curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path} && break || sleep 15; done
 bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}} || exit 1
 rm -fr genconf/serve/upgrade/current
 cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current


### PR DESCRIPTION
On very slow or bad network environments, its better to retry on behalf of the user up to at most 5 times until a failure is reported.